### PR TITLE
Introduce packages.kde

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ corresponding Qt or KF version.
 In addition, add the library to [packages.qt6](packages.qt6) or 
 [packages.kf6](packages.kf6) files. 
 
+For packages and libraries from KPIM or KDE Applications which use common
+versioning scheme (usually YY.MM.R, for year, month, and a counter),
+[packages.kde](packages.kde) is handled in the same way. The macro name is
+`kde_version` for these.
+
 By using these macros and having library added into packages files, it
 will be possible to update the libraries automatically on the next Qt
 or KF version bump.

--- a/packages.kde
+++ b/packages.kde
@@ -1,0 +1,1 @@
+kpublictransport

--- a/scripts/update-obs-packages.sh
+++ b/scripts/update-obs-packages.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-ARGS_PROCESSED=$(getopt -o kqrt --long kf6,qt6,release,testing -- "$@")
+ARGS_PROCESSED=$(getopt -o kqKrt --long kf6,qt6,kde,release,testing -- "$@")
 
 INPUT=
 KF6=
@@ -15,6 +15,7 @@ while [ : ]; do
   case "$1" in
     -k | --kf6) KF6=1; INPUT=packages.kf6; shift; ;;
     -q | --qt6) QT6=1; INPUT=packages.qt6; shift; ;;
+    -K | --kde) KDE=1; INPUT=packages.kde; shift; ;;
     -r | --release) OBS_PROJECT=sailfishos:chum; shift; ;;
     -t | --testing) OBS_PROJECT=sailfishos:chum:testing; shift; ;;
     --) shift; break; ;;
@@ -22,8 +23,8 @@ while [ : ]; do
 done
 
 # check options
-[ -z "$KF6" ] && [ -z "$QT6" ] && echo "Specify whether KF6 or QT6 is updated" && exit 1
-[ ! -z "$KF6" ] && [ ! -z "$QT6" ] && echo "Specify either KF6 or QT6 is updated" && exit 1
+[ -z "$KF6" ] && [ -z "$QT6" ] && [ -z "$KDE" ] && echo "Specify whether KDE, KF6 or QT6 is updated" && exit 1
+[ ! -z "$KF6" ] && [ ! -z "$QT6" ] && [ ! -z "$KDE" ] && echo "Specify either KDE, KF6 or QT6 is updated" && exit 1
 [ -z "$OBS_PROJECT" ] && echo "Specify whether you want to update release (sailfishos:chum) or testing (sailfishos:chum:testing) OBS project" && exit 1
 [ -z "$INPUT" ] && echo "Input file missing" && exit 1
 

--- a/scripts/update-obs-targets.sh
+++ b/scripts/update-obs-targets.sh
@@ -8,6 +8,7 @@ ADD=
 DEL=
 KF6=
 QT6=
+KDE=
 OBS_PROJECT=
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd -P )
 OBSMOD=${SCRIPT_DIR}/obsbuildmod.py
@@ -39,7 +40,7 @@ while read -r line; do
     package_obs=$package_git
     (( ${#package_arr[@]} > 1 )) && [ ${package_arr[1]} != "NOGIT" ] && [ ${package_arr[1]} != "NOAUTO" ] && package_obs=${package_arr[1]}
     PACKAGES="$PACKAGES $package_obs"
-done < <(cat packages.qt6 packages.kf6 | grep -v NOOBS)
+done < <(cat packages.qt6 packages.kf6 packages.kde | grep -v NOOBS)
 PACKAGES="$PACKAGES `cat applications.obs`"
 
 echo $PACKAGES

--- a/scripts/update-sources.sh
+++ b/scripts/update-sources.sh
@@ -2,11 +2,12 @@
 
 set -e
 
-ARGS_PROCESSED=$(getopt -o kqv: --long kf6,qt6,version: -- "$@")
+ARGS_PROCESSED=$(getopt -o kqKv: --long kf6,qt6,kde,version: -- "$@")
 
 INPUT=
 KF6=
 QT6=
+KDE=
 VERSION=
 GITHUB_BASE=https://github.com/sailfishos-chum
 
@@ -15,6 +16,7 @@ while [ : ]; do
   case "$1" in
     -k | --kf6) KF6=1; INPUT=packages.kf6; shift; ;;
     -q | --qt6) QT6=1; INPUT=packages.qt6; shift; ;;
+    -K | --kde) KDE=1; INPUT=packages.kde; shift; ;;
     -v | --version) VERSION=$2; shift 2; ;;
     --) shift; break; ;;
   esac
@@ -23,8 +25,8 @@ done
 # check options
 [ -z "$INPUT" ] && echo "Input file missing" && exit 1
 [ -z "$VERSION" ] && echo "Target version missing" && exit 1
-[ -z "$KF6" ] && [ -z "$QT6" ] && echo "Specify whether KF6 or QT6 is updated" && exit 1
-[ ! -z "$KF6" ] && [ ! -z "$QT6" ] && echo "Specify either KF6 or QT6 is updated" && exit 1
+[ -z "$KF6" ] && [ -z "$QT6" ]  && [ -z "$KDE" ] && echo "Specify whether KDE, KF6, or QT6 is updated" && exit 1
+[ ! -z "$KF6" ] && [ ! -z "$QT6" ]  && [ ! -z "$KDE" ] && echo "Specify either KDE, KF6, or QT6 is updated" && exit 1
 
 [ -d tmp ] && echo "Directory tmp exists. Please remove before starting." && exit 1
 
@@ -51,6 +53,8 @@ while read -r line; do
 	sed -i "s/^%global kf6_version .*/%global kf6_version ${VERSION}/g" rpm/*.spec
     elif [ $QT6 ]; then
 	sed -i "s/^%global qt_version .*/%global qt_version ${VERSION}/g" rpm/*.spec
+    elif [ $KDE ]; then
+	sed -i "s/^%global kde_version .*/%global kde_version ${VERSION}/g" rpm/*.spec
     fi
     git add rpm/*.spec
     git status

--- a/updates.md
+++ b/updates.md
@@ -13,6 +13,9 @@ scripts:
 
 - [packages.kf6](packages.kf6) - KDE Frameworks packages;
 
+- [packages.kde](packages.kde) - List of applications and
+  libraries that are using the KDE Applications versioning scheme (YY.MM.R).
+
 - [applications.obs](applications.obs) - List of applications and
   libraries that are using Qt6 or KF6 packages listed above.
 
@@ -64,6 +67,9 @@ Update instructions for Qt6 or KF6:
 - For KF6, run after replacing a version:
   - `scripts/update-sources.sh --kf6 --version 6.6.0`
 
+- For KDE/Plasma, run after replacing a version:
+  - `scripts/update-sources.sh --kde --version 24.08.2`
+
 - Observe that the script runs till the end without errors. If there
   are errors, investigate and see what went wrong. You can rerun
   `update-sources.sh` script several times - it will push changes to
@@ -84,6 +90,7 @@ Update instructions for Qt6 or KF6:
 - For updating packages at OBS `sailfishos:chum:testing`, run
   - for Qt6: `scripts/update-obs-packages.sh --qt6 --testing`
   - for KF6: `scripts/update-obs-packages.sh --kf6 --testing`
+  - for KDE: `scripts/update-obs-packages.sh --kde --testing`
 
 - Wait till update is finished and test it
 
@@ -91,6 +98,7 @@ Update instructions for Qt6 or KF6:
   of the script:
   - for Qt6: `scripts/update-obs-packages.sh --qt6 --release`
   - for KF6: `scripts/update-obs-packages.sh --kf6 --release`
+  - for KDE: `scripts/update-obs-packages.sh --kde --release`
 
 
 ## To change OBS targets


### PR DESCRIPTION
As discussed briefly on IRC, introduce a new category for packages with a
common scheme, currently KDE Applications as well as KPIM use YY.MM.R as
versions.

https://irclogs.sailfishos.org/logs/%23sailfishos/%23sailfishos.2024-10-18.log.html
https://irclogs.sailfishos.org/logs/%23sailfishos/%23sailfishos.2024-10-19.log.html
