### PR TITLE
Make scatchbox2 (sb2) output quieter

### DIFF
--- a/macros.qt6
+++ b/macros.qt6
@@ -39,9 +39,19 @@
   QMAKE_LFLAGS_RELEASE="${LDFLAGS:-%{_qt6_ldflags}}" \\\
   QMAKE_STRIP=
 
-%qmake_qt6 %{_qt6_qmake} %{?_qt6_qmake_flags}
+%_sbox_mapping_loglevel error
+%_sbox_quiet 0
+
+%_qt6_set_sbox_env \
+ SBOX_MAPPING_LOGLEVEL="%{_sbox_mapping_loglevel}"; export SBOX_MAPPING_LOGLEVEL; \
+ SBOX_QUIET=%{_sbox_quiet}; export SBOX_QUIET;
+
+%qmake_qt6 \
+ %_qt6_set_sbox_env \
+ %{_qt6_qmake} %{?_qt6_qmake_flags}
 
 %cmake_qt6 \
+ %_qt6_set_sbox_env \
  %cmake -DCMAKE_BUILD_TYPE=%{_qt6_build_type} \\\
         -DCMAKE_INSTALL_PREFIX=%{_qt6_prefix} \\\
 %if "%_qt6_build_tool" == "ninja" \


### PR DESCRIPTION
Not sure if that's the formally totally correct way to do it but it works.

References:

 - [sb2/sblib/sb\_log.c](https://github.com/sailfishos/scratchbox2/blob/eb3ac0bc2c68c9555d3be435071bc378847dbe18/sblib/sb_log.c#L159)
 - [sb2/utils/sb2](https://github.com/sailfishos/scratchbox2/blob/eb3ac0bc2c68c9555d3be435071bc378847dbe18/utils/sb2#L475)
